### PR TITLE
Add docker-compose setup for ejabberd stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,45 @@
 # rumessendger
+
+This repository contains a simple Docker Compose setup for the messaging stack
+based on **ejabberd**, **PostgreSQL**, **Redis** and **MinIO**. It is intended for
+local development and experimentation.
+
+## Running the stack
+
+1. Ensure Docker and Docker Compose are installed.
+2. Start all services:
+
+   ```bash
+   docker-compose up -d
+   ```
+3. The services will be available on their default ports:
+   - ejabberd: 5222 (C2S), 5269 (S2S), 5280 (Web/HTTP Upload)
+   - PostgreSQL: 5432
+   - Redis: 6379
+   - MinIO: 9000 (API) and 9001 (console)
+
+## TLS certificates
+
+The `docker-compose.yml` mounts a local `certs/` directory into the ejabberd
+container. Place your TLS certificate and key in this directory as
+`fullchain.pem` and `privkey.pem` respectively:
+
+```bash
+mkdir certs
+# copy your certificate files into the certs/ directory
+```
+
+You can obtain certificates from Let's Encrypt using tools such as
+[Certbot](https://certbot.eff.org/) or create self-signed certificates with
+`openssl` for testing purposes.
+
+After adding or renewing certificates, restart ejabberd:
+
+```bash
+docker-compose restart ejabberd
+```
+
+## Configuration
+
+The ejabberd configuration is located at `ejabberd/ejabberd.yml`. Adjust this
+file to enable additional modules or change database credentials as needed.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,55 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: postgres:15
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ejabberd
+      POSTGRES_PASSWORD: ejabberd
+      POSTGRES_DB: ejabberd
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minio
+      MINIO_ROOT_PASSWORD: minio123
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - minio_data:/data
+
+  ejabberd:
+    image: ghcr.io/processone/ejabberd:23.10
+    restart: unless-stopped
+    depends_on:
+      - postgres
+      - redis
+      - minio
+    environment:
+      ERLANG_NODE: ejabberd@localhost
+      EJABBERD_LOGLEVEL: 4
+      EJABBERD_CERTFILE: /home/ejabberd/certs/fullchain.pem
+      EJABBERD_KEYFILE: /home/ejabberd/certs/privkey.pem
+    volumes:
+      - ./ejabberd/ejabberd.yml:/home/ejabberd/conf/ejabberd.yml:ro
+      - ./certs:/home/ejabberd/certs:ro
+    ports:
+      - "5222:5222"
+      - "5269:5269"
+      - "5280:5280"
+
+volumes:
+  postgres_data:
+  redis_data:
+  minio_data:

--- a/ejabberd/ejabberd.yml
+++ b/ejabberd/ejabberd.yml
@@ -1,0 +1,44 @@
+hosts:
+  - "localhost"
+
+certfiles:
+  - /home/ejabberd/certs/fullchain.pem
+
+listen:
+  -
+    port: 5222
+    module: ejabberd_c2s
+    starttls: true
+  -
+    port: 5269
+    module: ejabberd_s2s_in
+  -
+    port: 5280
+    module: ejabberd_http
+    request_handlers:
+      "/upload": mod_http_upload
+
+auth_method: sql
+sql_type: pgsql
+sql_server: postgres
+sql_database: ejabberd
+sql_username: ejabberd
+sql_password: ejabberd
+
+redis_server: redis
+
+modules:
+  mod_stream_mgmt: {}
+  mod_mam:
+    db_type: sql
+  mod_carboncopy: {}
+  mod_push: {}
+  mod_http_upload:
+    max_size: 10485760
+    s3:
+      host: minio
+      port: 9000
+      bucket: uploads
+      access_key_id: minio
+      secret_access_key: minio123
+      scheme: http


### PR DESCRIPTION
## Summary
- Add Docker Compose configuration with ejabberd, PostgreSQL, Redis and MinIO services
- Provide ejabberd configuration enabling key XMPP modules and SQL credentials
- Document running the stack and managing TLS certificates in the README

## Testing
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689db63bae08832fae473374f4af6ce4