### PR TITLE
Add push gateway service

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@
 
 - **Upload Service** – provides pre-signed S3 URLs for HTTP file uploads.
   See [services/upload](services/upload/README.md).
+- **Push Gateway** – accepts push notifications from ejabberd and forwards
+  them to FCM or HMS.
+  See [services/push-gateway](services/push-gateway/README.md).
 
 =======
 This repository contains a simple Docker Compose setup for the messaging stack

--- a/services/push-gateway/README.md
+++ b/services/push-gateway/README.md
@@ -1,0 +1,48 @@
+# Push Gateway
+
+This service receives push notifications from ejabberd and forwards them to
+mobile push providers like Firebase Cloud Messaging (FCM) and Huawei Mobile
+Services (HMS).
+
+## Environment variables
+
+- `PORT` – HTTP port to listen on (default `8000`).
+- `FCM_SERVER_KEY` – server key for Firebase Cloud Messaging.
+- `HMS_APP_ID` – Huawei application ID.
+- `HMS_CLIENT_ID` – Huawei client ID.
+- `HMS_CLIENT_SECRET` – Huawei client secret.
+
+## API
+
+### `GET /health`
+
+Returns `200 OK` with body `ok`.
+
+### `POST /push`
+
+Request body:
+
+```json
+{
+  "platform": "fcm",   // or "hms"
+  "token": "device-token",
+  "title": "Hello",
+  "body": "World"
+}
+```
+
+The service forwards the notification to the selected provider.
+On success a `202 Accepted` response is returned.
+
+## ejabberd integration
+
+Configure ejabberd to delegate push notifications to this gateway:
+
+```yaml
+modules:
+  mod_push:
+    service_url: http://push-gateway:8000/push
+```
+
+Ejabberd will POST the notification payload and the gateway will relay it to
+the appropriate mobile push service.

--- a/services/push-gateway/push_gateway.py
+++ b/services/push-gateway/push_gateway.py
@@ -1,0 +1,122 @@
+import os
+import json
+import urllib.request
+import urllib.parse
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def send_fcm(token: str, title: str, body: str) -> None:
+    server_key = os.environ['FCM_SERVER_KEY']
+    message = {
+        'to': token,
+        'notification': {'title': title, 'body': body},
+    }
+    req = urllib.request.Request(
+        'https://fcm.googleapis.com/fcm/send',
+        data=json.dumps(message).encode('utf-8'),
+        headers={
+            'Content-Type': 'application/json',
+            'Authorization': f'key={server_key}',
+        },
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        resp.read()
+
+
+def _hms_access_token() -> str:
+    data = urllib.parse.urlencode({
+        'grant_type': 'client_credentials',
+        'client_id': os.environ['HMS_CLIENT_ID'],
+        'client_secret': os.environ['HMS_CLIENT_SECRET'],
+    }).encode('utf-8')
+    req = urllib.request.Request(
+        'https://oauth-login.cloud.huawei.com/oauth2/v3/token',
+        data=data,
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        payload = json.loads(resp.read().decode('utf-8'))
+        return payload['access_token']
+
+
+def send_hms(token: str, title: str, body: str) -> None:
+    app_id = os.environ['HMS_APP_ID']
+    access_token = _hms_access_token()
+    url = f'https://push-api.cloud.huawei.com/v1/{app_id}/messages:send'
+    message = {
+        'validate_only': False,
+        'message': {
+            'token': [token],
+            'notification': {'title': title, 'body': body},
+        },
+    }
+    req = urllib.request.Request(
+        url,
+        data=json.dumps(message).encode('utf-8'),
+        headers={
+            'Content-Type': 'application/json;charset=utf-8',
+            'Authorization': f'Bearer {access_token}',
+        },
+    )
+    with urllib.request.urlopen(req) as resp:  # noqa: S310
+        resp.read()
+
+
+class PushGatewayHandler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path == '/health':
+            self.send_response(200)
+            self.send_header('Content-Type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b'ok')
+        else:
+            self.send_response(404)
+            self.end_headers()
+
+    def do_POST(self):  # noqa: N802
+        if self.path != '/push':
+            self.send_response(404)
+            self.end_headers()
+            return
+        length = int(self.headers.get('Content-Length', '0'))
+        body = self.rfile.read(length)
+        try:
+            data = json.loads(body)
+            platform = data['platform']
+            token = data['token']
+            title = data.get('title', '')
+            message = data.get('body', '')
+        except Exception:  # noqa: BLE001
+            self.send_response(400)
+            self.end_headers()
+            return
+
+        try:
+            if platform == 'fcm':
+                send_fcm(token, title, message)
+            elif platform == 'hms':
+                send_hms(token, title, message)
+            else:
+                raise ValueError('unknown platform')
+        except Exception:  # noqa: BLE001
+            self.send_response(500)
+            self.end_headers()
+            return
+
+        self.send_response(202)
+        self.end_headers()
+
+
+def make_server(port: int | None = None) -> HTTPServer:
+    address = ('', port or int(os.environ.get('PORT', 8000)))
+    return HTTPServer(address, PushGatewayHandler)
+
+
+if __name__ == '__main__':
+    httpd = make_server()
+    try:
+        httpd.serve_forever()
+    except KeyboardInterrupt:  # pragma: no cover
+        pass
+    finally:
+        httpd.server_close()


### PR DESCRIPTION
## Summary
- implement push gateway HTTP server forwarding to FCM and HMS
- document push gateway usage and configuration
- register new push gateway in main README

## Testing
- `python services/push-gateway/test_push_gateway.py`
- `python services/upload/test_upload_service.py`


------
https://chatgpt.com/codex/tasks/task_e_689dbb820a60832fb6568e4b1a10fbe5