### PR TITLE
Pin Docker images and improve infrastructure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,37 @@
+# Database configuration
+POSTGRES_USER=ejabberd
+POSTGRES_PASSWORD=ejabberd
+POSTGRES_DB=ejabberd
+
+# MinIO credentials
+MINIO_ROOT_USER=minio
+MINIO_ROOT_PASSWORD=minio123
+
+# Ejabberd configuration
+ERLANG_NODE=ejabberd@localhost
+EJABBERD_LOGLEVEL=4
+EJABBERD_CERTFILE=/home/ejabberd/certs/fullchain.pem
+EJABBERD_KEYFILE=/home/ejabberd/certs/privkey.pem
+
+# Upload service
+PORT=8000
+S3_ENDPOINT=http://minio:9000
+S3_REGION=us-east-1
+S3_ACCESS_KEY=minio
+S3_SECRET_KEY=minio123
+S3_BUCKET=uploads
+MAX_UPLOAD_SIZE=10485760
+ALLOWED_TYPES=image/png,image/jpeg
+UPLOAD_TTL=600
+CORS_ALLOW_ORIGIN=*
+
+# Push gateway
+ENV=DEV
+FCM_SERVER_KEY_DEV=your_fcm_dev_key
+FCM_SERVER_KEY_PROD=your_fcm_prod_key
+HMS_APP_ID=your_hms_app_id
+HMS_CLIENT_ID_DEV=your_hms_dev_client_id
+HMS_CLIENT_SECRET_DEV=your_hms_dev_client_secret
+HMS_CLIENT_ID_PROD=your_hms_prod_client_id
+HMS_CLIENT_SECRET_PROD=your_hms_prod_client_secret
+PUSH_RATE_LIMIT_SECONDS=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 __pycache__/
 *.pyc
+.env
 
-=======
 # Android build artifacts
 android/.gradle/
 android/build/

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Rumessendger provides a lightweight XMPP messaging stack for local development
 and experimentation.  The project bundles **ejabberd** with a SQL database,
 cache, object storage and auxiliary services so you can explore XMPP features
 without assembling the infrastructure yourself.
-=======
+
 - **Upload Service** – provides pre-signed S3 URLs for HTTP file uploads.
   See [services/upload](services/upload/README.md).
 - **Push Gateway** – accepts push notifications from ejabberd and forwards
@@ -51,7 +51,8 @@ for TLS support.  Self-signed certificates are sufficient for development.
 ### Environment variables
 
 The stack uses several environment variables which can be overridden with a
-`.env` file or in your shell:
+`.env` file or in your shell. An example configuration is provided in
+`.env.example`:
 
 - `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` – database credentials
   for ejabberd.
@@ -70,7 +71,7 @@ docker-compose up -d
 
 The services will be available on their default ports:
 
-- ejabberd: 5222 (C2S), 5269 (S2S), 5280 (Web/HTTP upload)
+- ejabberd: 5222 (C2S), 5280 (Web/HTTP upload)
 - PostgreSQL: 5432
 - Redis: 6379
 - MinIO: 9000 (API) and 9001 (console)
@@ -100,6 +101,12 @@ docker-compose restart ejabberd
 
 The ejabberd configuration is located at `ejabberd/ejabberd.yml`. Adjust this
 file to enable additional modules or change database credentials as needed.
+
+## Backups
+
+A helper script `scripts/backup.sh` performs a nightly PostgreSQL dump and
+records MinIO bucket versions. Configure a cron job to run it and store the
+artifacts in a secure location.
 
 ## Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,54 +2,76 @@ version: "3.8"
 
 services:
   postgres:
-    image: postgres:15
+    image: postgres:16
     restart: unless-stopped
     environment:
-      POSTGRES_USER: ejabberd
-      POSTGRES_PASSWORD: ejabberd
-      POSTGRES_DB: ejabberd
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - pg:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
-    image: redis:7-alpine
+    image: redis:7
     restart: unless-stopped
     volumes:
       - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   minio:
-    image: minio/minio
+    image: quay.io/minio/minio:RELEASE.2025-02-07T20-11-15Z
     command: server /data --console-address ":9001"
     environment:
-      MINIO_ROOT_USER: minio
-      MINIO_ROOT_PASSWORD: minio123
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD}
     ports:
       - "9000:9000"
       - "9001:9001"
     volumes:
-      - minio_data:/data
+      - minio:/data
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
 
   ejabberd:
-    image: ghcr.io/processone/ejabberd:23.10
+    image: ghcr.io/processone/ejabberd:24.02
     restart: unless-stopped
     depends_on:
-      - postgres
-      - redis
-      - minio
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
     environment:
-      ERLANG_NODE: ejabberd@localhost
-      EJABBERD_LOGLEVEL: 4
-      EJABBERD_CERTFILE: /home/ejabberd/certs/fullchain.pem
-      EJABBERD_KEYFILE: /home/ejabberd/certs/privkey.pem
+      ERLANG_NODE: ${ERLANG_NODE}
+      EJABBERD_LOGLEVEL: ${EJABBERD_LOGLEVEL}
+      EJABBERD_CERTFILE: ${EJABBERD_CERTFILE}
+      EJABBERD_KEYFILE: ${EJABBERD_KEYFILE}
     volumes:
       - ./ejabberd/ejabberd.yml:/home/ejabberd/conf/ejabberd.yml:ro
       - ./certs:/home/ejabberd/certs:ro
     ports:
       - "5222:5222"
-      - "5269:5269"
       - "5280:5280"
+    healthcheck:
+      test: ["CMD", "ejabberdctl", "status"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
 
 volumes:
-  postgres_data:
+  pg:
   redis_data:
-  minio_data:
+  minio:

--- a/ejabberd/ejabberd.yml
+++ b/ejabberd/ejabberd.yml
@@ -3,15 +3,13 @@ hosts:
 
 certfiles:
   - /home/ejabberd/certs/fullchain.pem
+  - /home/ejabberd/certs/privkey.pem
 
 listen:
   -
     port: 5222
     module: ejabberd_c2s
     starttls: true
-  -
-    port: 5269
-    module: ejabberd_s2s_in
   -
     port: 5280
     module: ejabberd_http
@@ -21,24 +19,31 @@ listen:
 auth_method: sql
 sql_type: pgsql
 sql_server: postgres
-sql_database: ejabberd
-sql_username: ejabberd
-sql_password: ejabberd
+sql_database: "${POSTGRES_DB}"
+sql_username: "${POSTGRES_USER}"
+sql_password: "${POSTGRES_PASSWORD}"
 
 redis_server: redis
+
+ciphers: "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256"
 
 modules:
   mod_stream_mgmt: {}
   mod_mam:
+    default: always
     db_type: sql
   mod_carboncopy: {}
-  mod_push: {}
+  mod_push:
+    service_jid: push.localhost
+  mod_push_keepalive: {}
   mod_http_upload:
     max_size: 10485760
+    custom_headers:
+      Access-Control-Allow-Origin: "*"
     s3:
       host: minio
       port: 9000
       bucket: uploads
-      access_key_id: minio
-      secret_access_key: minio123
+      access_key_id: "${MINIO_ROOT_USER}"
+      secret_access_key: "${MINIO_ROOT_PASSWORD}"
       scheme: http

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+
+DATE=$(date +%Y%m%d)
+BACKUP_DIR=${BACKUP_DIR:-/backups}
+mkdir -p "$BACKUP_DIR"
+
+pg_dump -h ${PGHOST:-postgres} -U ${POSTGRES_USER:-ejabberd} ${POSTGRES_DB:-ejabberd} > "$BACKUP_DIR/db_$DATE.sql"
+
+mc ls --versions ${MINIO_ALIAS:-minio}/${MINIO_BUCKET:-uploads} > "$BACKUP_DIR/minio_versions_$DATE.txt"

--- a/services/upload/test_upload_service.py
+++ b/services/upload/test_upload_service.py
@@ -12,6 +12,10 @@ os.environ['S3_SECRET_KEY'] = 'secret'
 os.environ['S3_REGION'] = 'us-east-1'
 os.environ['S3_ENDPOINT'] = 'http://localhost:9000'
 os.environ['S3_BUCKET'] = 'bucket'
+os.environ['MAX_UPLOAD_SIZE'] = '1024'
+os.environ['ALLOWED_TYPES'] = 'text/plain'
+os.environ['UPLOAD_TTL'] = '600'
+os.environ['CORS_ALLOW_ORIGIN'] = '*'
 
 sys.path.append(str(Path(__file__).resolve().parent))
 import upload_service  # noqa: E402
@@ -24,7 +28,11 @@ class UploadServiceTest(unittest.TestCase):
         thread.start()
         port = httpd.server_address[1]
 
-        data = json.dumps({'filename': 'hello.txt'}).encode('utf-8')
+        data = json.dumps({
+            'filename': 'hello.txt',
+            'size': 10,
+            'content_type': 'text/plain',
+        }).encode('utf-8')
         req = urllib.request.Request(
             f'http://localhost:{port}/slot',
             data=data,


### PR DESCRIPTION
## Summary
- pin Postgres, Redis, MinIO and ejabberd images in docker-compose with healthchecks and volume names
- expose secrets via `.env` template and add nightly backup script
- tighten upload service limits and add push gateway registration with rate limiting

## Testing
- `python services/upload/test_upload_service.py`
- `python services/push-gateway/test_push_gateway.py`
- `docker-compose config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dc8a66f64832f85c3ada1a5ed1be6