### PR TITLE
Add Makefile, CI workflow, and Quick Start docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+      - run: pip install yamllint
+      - run: yamllint .
+
+  android:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+      - name: Run lint and build
+        run: |
+          cd android
+          chmod +x gradlew
+          ./gradlew lint assembleDebug
+
+  docker:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build upload service
+        run: docker build services/upload -t upload-service
+      - name: Build push gateway
+        run: docker build services/push-gateway -t push-gateway

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: up down logs psql backup
+
+up:
+	docker compose up -d
+
+down:
+	docker compose down
+
+logs:
+	docker compose logs -f
+
+psql:
+	docker compose exec postgres psql -U $${POSTGRES_USER:-ejabberd} $${POSTGRES_DB:-ejabberd}
+
+backup:
+	./scripts/backup.sh

--- a/README.md
+++ b/README.md
@@ -62,6 +62,13 @@ The stack uses several environment variables which can be overridden with a
 - `PORT`, `S3_ENDPOINT`, `S3_REGION`, `S3_ACCESS_KEY`, `S3_SECRET_KEY`,
   `S3_BUCKET` – upload service configuration.
 
+Create a `.env` file from the provided template:
+
+```bash
+cp .env.example .env
+```
+
+
 ### Launching the stack
 
 ```bash
@@ -75,6 +82,22 @@ The services will be available on their default ports:
 - PostgreSQL: 5432
 - Redis: 6379
 - MinIO: 9000 (API) and 9001 (console)
+
+
+### Example requests
+
+Request a slot from the upload service (XEP-0363):
+
+```bash
+curl -X POST http://localhost:8000/slot -H "Content-Type: application/json" -d '{"filename":"hello.txt","size":10,"content_type":"text/plain"}'
+```
+
+Register a device and send a push notification:
+
+```bash
+curl -X POST http://localhost:8000/register -H "Content-Type: application/json" -d '{"token":"abc","jid":"u@d","resource":"r","platform":"fcm"}'
+curl -X POST http://localhost:8000/push -H "Content-Type: application/json" -d '{"token":"abc","title":"Hi","body":"Message"}'
+```
 
 ## TLS certificates
 
@@ -114,4 +137,3 @@ artifacts in a secure location.
 - [Upload Service](services/upload/README.md)
 - [Push Gateway](https://github.com/rumessendger/push-gateway)
 - [Android Client](https://github.com/rumessendger/android-client)
-

--- a/services/push-gateway/Dockerfile
+++ b/services/push-gateway/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY push_gateway.py .
+EXPOSE 8000
+CMD ["python", "push_gateway.py"]

--- a/services/upload/Dockerfile
+++ b/services/upload/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY upload_service.py .
+EXPOSE 8000
+CMD ["python", "upload_service.py"]


### PR DESCRIPTION
## Summary
- add root Makefile with helper targets for compose lifecycle, psql and backups
- build upload and push microservices via Dockerfiles and CI workflow
- expand README Quick Start with .env setup and curl examples

## Testing
- `python services/upload/test_upload_service.py`
- `python services/push-gateway/test_push_gateway.py`
- `pip install yamllint` *(fails: Tunnel connection failed: 403 Forbidden)*
- `docker build services/upload` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dd4b86378832f8847a1d7009e2bb6